### PR TITLE
Make work across isolates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- fix bug to allow name server to actually work across multiple isolates
+
 ## 1.0.1
 
 - lower min SDK version

--- a/lib/src/isolate_registry.dart
+++ b/lib/src/isolate_registry.dart
@@ -74,7 +74,6 @@ abstract final class IsolateNameServer {
     final lookupPortByName =
         lookupPortByNamePointer.asFunction<_LookupPortByName>();
     final port = lookupPortByName(name.toNativeUtf8());
-    print("port: $port");
     if (port != null) {
       return port as SendPort;
     } else {

--- a/native/isolate_name_server.c
+++ b/native/isolate_name_server.c
@@ -7,9 +7,14 @@
 
 static struct hashmap_s hashmap;
 pthread_mutex_t lock;
+int initDone = 0;
 
 int initNameServer() {
-    const unsigned initial_size = 10;    
+    if (initDone == 1) {
+        return 0;
+    }
+    const unsigned initial_size = 10;
+    initDone = 1;   
     return hashmap_create(initial_size, &hashmap);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: isolate_name_server
 description: A registry for SendPorts that can be used across Isolates.
-version: 1.0.1
+version: 1.1.0
 repository: https://github.com/maks/isolate_name_server
 
 environment:

--- a/test/isolate_name_server_test.dart
+++ b/test/isolate_name_server_test.dart
@@ -55,5 +55,25 @@ void main() {
       final found = IsolateNameServer.lookupPortByName(portName);
       expect(found, isNull);
     });
+
+    test('lookup works across Isolates', () async {
+      final portName = "tester";
+      ReceivePort rp = ReceivePort();
+      IsolateNameServer.registerPortWithName(rp.sendPort, portName);
+
+      Isolate.spawn((_) {
+        final found = IsolateNameServer.lookupPortByName(portName);
+        found?.send("x");
+      }, null);
+
+      expect(IsolateNameServer.lookupPortByName(portName), isNotNull);
+
+      bool gotMesg = false;
+      rp.listen((message) => gotMesg = true);
+
+      await Future.delayed(Duration(seconds: 1));
+
+      expect(gotMesg, isTrue);
+    });
   });
 }


### PR DESCRIPTION
Fix bug where init would create new hashmap everytime it was called per each Isolate.